### PR TITLE
Revamp docs, error messaging, and add more missing aarch64 headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,50 @@
 # fetch-them-macos-headers
 
-This is a small, simplistic utility that can be used to fetch and copy over a standard set of libc headers
-as described [here] on macOS. The intention for this utility is to use it to update the libc headers shipped
-with [Zig], and used when cross-compiling to macOS (see [this article] for an amazing description of the `zig cc`
-C compiler frontend).
+This is a small utility that can be used to fetch and generate deduplicated macOS libc headers. The intention for
+this utility is to use it to update the libc headers shipped with [Zig], and used when cross-compiling to macOS
+(see [this article] for an amazing description of the `zig cc` C compiler frontend).
 
-[here]: https://en.wikipedia.org/wiki/C_standard_library
 [Zig]: https://ziglang.org
 [this article]: https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html
 
 ## Howto
 
-Building is straightforward, although I should point out, with the current limitations of the lld linker,
-you should build the project natively on macOS
+**NOTE: it makes little sense running this utility on a non-macOS host.**
+
+1. Build
 
 ```
 zig build
 ```
 
-Running the generated binary `fetch_them_macos_headers` will create a new dir `x86_64-macos-gnu` with all
-libc headers copied over
+2. (Optional) Add additional libc headers to `src/headers.c`.
+
+3. Fetch headers into `libc/include/<arch>-macos-gnu`
 
 ```
-zig-cache/bin/fetch_them_macos_headers [cflags]
+./zig-cache/bin/fetch_them_macos_headers fetch
 ```
 
-Currently there are no known cflags needed.
+4. Generate deduplicated headers dirs in `<destination>` path
+
+```
+./zig-cache/bin/fetch_them_macos_headers generate <destination>
+```
+
+5. (Optional) Copy the contents of `<destination>` into Zig's `lib/libc/include/`, and analyze the changes with
+   `git status`.
+
+## Usage
+
+```
+Usage: fetch_them_macos_headers fetch [cflags]
+       fetch_them_macos_headers generate <destination>
+
+Commands:
+  fetch [cflags]              Fetch libc headers into libc/include/<arch>-macos-gnu dir
+  generate <destination>      Generate deduplicated dirs { aarch64-macos-gnu, x86_64-macos-gnu, any-macos-any }
+                              into a given <destination> path
+
+General Options:
+-h, --help                    Print this help and exit
+```

--- a/libc/include/aarch64-macos-gnu/CommonCrypto/CommonDigest.h
+++ b/libc/include/aarch64-macos-gnu/CommonCrypto/CommonDigest.h
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2004 Apple Computer, Inc. All Rights Reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+/*
+ * CommonDigest.h - common digest routines: MD2, MD4, MD5, SHA1.
+ */
+
+#ifndef _CC_COMMON_DIGEST_H_
+#define _CC_COMMON_DIGEST_H_
+
+#include <stdint.h>
+
+#if defined(_MSC_VER)
+#include <availability.h>
+#else
+#include <os/availability.h>
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CC_DIGEST_DEPRECATION_WARNING                                                                                          \
+    "This function is cryptographically broken and should not be used in security contexts. Clients should migrate to SHA256 (or stronger)."
+
+/*
+ * For compatibility with legacy implementations, the *Init(), *Update(),
+ * and *Final() functions declared here *always* return a value of 1 (one).
+ * This corresponds to "success" in the similar openssl implementations.
+ * There are no errors of any kind which can be, or are, reported here,
+ * so you can safely ignore the return values of all of these functions
+ * if you are implementing new code.
+ *
+ * The one-shot functions (CC_MD2(), CC_SHA1(), etc.) perform digest
+ * calculation and place the result in the caller-supplied buffer
+ * indicated by the md parameter. They return the md parameter.
+ * Unlike the opensssl counterparts, these one-shot functions require
+ * a non-NULL md pointer. Passing in NULL for the md parameter
+ * results in a NULL return and no digest calculation.
+ */
+
+typedef uint32_t CC_LONG;       /* 32 bit unsigned integer */
+typedef uint64_t CC_LONG64;     /* 64 bit unsigned integer */
+
+/*** MD2 ***/
+
+#define CC_MD2_DIGEST_LENGTH    16          /* digest length in bytes */
+#define CC_MD2_BLOCK_BYTES      64          /* block size in bytes */
+#define CC_MD2_BLOCK_LONG       (CC_MD2_BLOCK_BYTES / sizeof(CC_LONG))
+
+typedef struct CC_MD2state_st
+{
+    int num;
+    unsigned char data[CC_MD2_DIGEST_LENGTH];
+    CC_LONG cksm[CC_MD2_BLOCK_LONG];
+    CC_LONG state[CC_MD2_BLOCK_LONG];
+} CC_MD2_CTX;
+
+extern int CC_MD2_Init(CC_MD2_CTX *c)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern int CC_MD2_Update(CC_MD2_CTX *c, const void *data, CC_LONG len)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern int CC_MD2_Final(unsigned char *md, CC_MD2_CTX *c)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern unsigned char *CC_MD2(const void *data, CC_LONG len, unsigned char *md)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+/*** MD4 ***/
+
+#define CC_MD4_DIGEST_LENGTH    16          /* digest length in bytes */
+#define CC_MD4_BLOCK_BYTES      64          /* block size in bytes */
+#define CC_MD4_BLOCK_LONG       (CC_MD4_BLOCK_BYTES / sizeof(CC_LONG))
+
+typedef struct CC_MD4state_st
+{
+    CC_LONG A,B,C,D;
+    CC_LONG Nl,Nh;
+    CC_LONG data[CC_MD4_BLOCK_LONG];
+    uint32_t num;
+} CC_MD4_CTX;
+
+extern int CC_MD4_Init(CC_MD4_CTX *c)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern int CC_MD4_Update(CC_MD4_CTX *c, const void *data, CC_LONG len)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern int CC_MD4_Final(unsigned char *md, CC_MD4_CTX *c)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern unsigned char *CC_MD4(const void *data, CC_LONG len, unsigned char *md)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+
+/*** MD5 ***/
+
+#define CC_MD5_DIGEST_LENGTH    16          /* digest length in bytes */
+#define CC_MD5_BLOCK_BYTES      64          /* block size in bytes */
+#define CC_MD5_BLOCK_LONG       (CC_MD5_BLOCK_BYTES / sizeof(CC_LONG))
+
+typedef struct CC_MD5state_st
+{
+    CC_LONG A,B,C,D;
+    CC_LONG Nl,Nh;
+    CC_LONG data[CC_MD5_BLOCK_LONG];
+    int num;
+} CC_MD5_CTX;
+
+extern int CC_MD5_Init(CC_MD5_CTX *c)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+    
+extern int CC_MD5_Update(CC_MD5_CTX *c, const void *data, CC_LONG len)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+    
+extern int CC_MD5_Final(unsigned char *md, CC_MD5_CTX *c)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+extern unsigned char *CC_MD5(const void *data, CC_LONG len, unsigned char *md)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+/*** SHA1 ***/
+
+#define CC_SHA1_DIGEST_LENGTH   20          /* digest length in bytes */
+#define CC_SHA1_BLOCK_BYTES     64          /* block size in bytes */
+#define CC_SHA1_BLOCK_LONG      (CC_SHA1_BLOCK_BYTES / sizeof(CC_LONG))
+
+typedef struct CC_SHA1state_st
+{
+    CC_LONG h0,h1,h2,h3,h4;
+    CC_LONG Nl,Nh;
+    CC_LONG data[CC_SHA1_BLOCK_LONG];
+    int num;
+} CC_SHA1_CTX;
+
+extern int CC_SHA1_Init(CC_SHA1_CTX *c);
+
+extern int CC_SHA1_Update(CC_SHA1_CTX *c, const void *data, CC_LONG len);
+
+extern int CC_SHA1_Final(unsigned char *md, CC_SHA1_CTX *c);
+
+extern unsigned char *CC_SHA1(const void *data, CC_LONG len, unsigned char *md);
+
+/*** SHA224 ***/
+#define CC_SHA224_DIGEST_LENGTH     28          /* digest length in bytes */
+#define CC_SHA224_BLOCK_BYTES       64          /* block size in bytes */
+
+/* same context struct is used for SHA224 and SHA256 */
+typedef struct CC_SHA256state_st
+{   CC_LONG count[2];
+    CC_LONG hash[8];
+    CC_LONG wbuf[16];
+} CC_SHA256_CTX;
+
+extern int CC_SHA224_Init(CC_SHA256_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA224_Update(CC_SHA256_CTX *c, const void *data, CC_LONG len)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA224_Final(unsigned char *md, CC_SHA256_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern unsigned char *CC_SHA224(const void *data, CC_LONG len, unsigned char *md)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+
+/*** SHA256 ***/
+
+#define CC_SHA256_DIGEST_LENGTH     32          /* digest length in bytes */
+#define CC_SHA256_BLOCK_BYTES       64          /* block size in bytes */
+
+extern int CC_SHA256_Init(CC_SHA256_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA256_Update(CC_SHA256_CTX *c, const void *data, CC_LONG len)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA256_Final(unsigned char *md, CC_SHA256_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern unsigned char *CC_SHA256(const void *data, CC_LONG len, unsigned char *md)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+
+/*** SHA384 ***/
+
+#define CC_SHA384_DIGEST_LENGTH     48          /* digest length in bytes */
+#define CC_SHA384_BLOCK_BYTES      128          /* block size in bytes */
+
+/* same context struct is used for SHA384 and SHA512 */
+typedef struct CC_SHA512state_st
+{   CC_LONG64 count[2];
+    CC_LONG64 hash[8];
+    CC_LONG64 wbuf[16];
+} CC_SHA512_CTX;
+
+extern int CC_SHA384_Init(CC_SHA512_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA384_Update(CC_SHA512_CTX *c, const void *data, CC_LONG len)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA384_Final(unsigned char *md, CC_SHA512_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern unsigned char *CC_SHA384(const void *data, CC_LONG len, unsigned char *md)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+
+/*** SHA512 ***/
+
+#define CC_SHA512_DIGEST_LENGTH     64          /* digest length in bytes */
+#define CC_SHA512_BLOCK_BYTES      128          /* block size in bytes */
+
+extern int CC_SHA512_Init(CC_SHA512_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA512_Update(CC_SHA512_CTX *c, const void *data, CC_LONG len)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern int CC_SHA512_Final(unsigned char *md, CC_SHA512_CTX *c)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+extern unsigned char *CC_SHA512(const void *data, CC_LONG len, unsigned char *md)
+API_AVAILABLE(macos(10.4), ios(2.0));
+
+/*
+ * To use the above digest functions with existing code which uses
+ * the corresponding openssl functions, #define the symbol
+ * COMMON_DIGEST_FOR_OPENSSL in your client code (BEFORE including
+ * this file), and simply link against libSystem (or System.framework)
+ * instead of libcrypto.
+ *
+ * You can *NOT* mix and match functions operating on a given data
+ * type from the two implementations; i.e., if you do a CC_MD5_Init()
+ * on a CC_MD5_CTX object, do not assume that you can do an openssl-style
+ * MD5_Update() on that same context.
+ */
+
+#ifdef  COMMON_DIGEST_FOR_OPENSSL
+
+#define MD2_DIGEST_LENGTH           CC_MD2_DIGEST_LENGTH
+#define MD2_CTX                     CC_MD2_CTX
+#define MD2_Init                    CC_MD2_Init
+#define MD2_Update                  CC_MD2_Update
+#define MD2_Final                   CC_MD2_Final
+
+#define MD4_DIGEST_LENGTH           CC_MD4_DIGEST_LENGTH
+#define MD4_CTX                     CC_MD4_CTX
+#define MD4_Init                    CC_MD4_Init
+#define MD4_Update                  CC_MD4_Update
+#define MD4_Final                   CC_MD4_Final
+
+#define MD5_DIGEST_LENGTH           CC_MD5_DIGEST_LENGTH
+#define MD5_CTX                     CC_MD5_CTX
+#define MD5_Init                    CC_MD5_Init
+#define MD5_Update                  CC_MD5_Update
+#define MD5_Final                   CC_MD5_Final
+
+#define SHA_DIGEST_LENGTH           CC_SHA1_DIGEST_LENGTH
+#define SHA_CTX                     CC_SHA1_CTX
+#define SHA1_Init                   CC_SHA1_Init
+#define SHA1_Update                 CC_SHA1_Update
+#define SHA1_Final                  CC_SHA1_Final
+
+#define SHA224_DIGEST_LENGTH        CC_SHA224_DIGEST_LENGTH
+#define SHA256_CTX                  CC_SHA256_CTX
+#define SHA224_Init                 CC_SHA224_Init
+#define SHA224_Update               CC_SHA224_Update
+#define SHA224_Final                CC_SHA224_Final
+
+#define SHA256_DIGEST_LENGTH        CC_SHA256_DIGEST_LENGTH
+#define SHA256_Init                 CC_SHA256_Init
+#define SHA256_Update               CC_SHA256_Update
+#define SHA256_Final                CC_SHA256_Final
+
+#define SHA384_DIGEST_LENGTH        CC_SHA384_DIGEST_LENGTH
+#define SHA512_CTX                  CC_SHA512_CTX
+#define SHA384_Init                 CC_SHA384_Init
+#define SHA384_Update               CC_SHA384_Update
+#define SHA384_Final                CC_SHA384_Final
+
+#define SHA512_DIGEST_LENGTH        CC_SHA512_DIGEST_LENGTH
+#define SHA512_Init                 CC_SHA512_Init
+#define SHA512_Update               CC_SHA512_Update
+#define SHA512_Final                CC_SHA512_Final
+
+
+#endif  /* COMMON_DIGEST_FOR_OPENSSL */
+
+/*
+ * In a manner similar to that described above for openssl
+ * compatibility, these macros can be used to provide compatiblity
+ * with legacy implementations of MD5 using the interface defined
+ * in RFC 1321.
+ */
+
+#ifdef  COMMON_DIGEST_FOR_RFC_1321
+
+#define MD5_CTX                     CC_MD5_CTX
+#define MD5Init                     CC_MD5_Init
+#define MD5Update                   CC_MD5_Update
+
+void MD5Final (unsigned char [16], MD5_CTX *)
+API_DEPRECATED(CC_DIGEST_DEPRECATION_WARNING, macos(10.4, 10.15), ios(2.0, 13.0));
+
+#endif  /* COMMON_DIGEST_FOR_RFC_1321 */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _CC_COMMON_DIGEST_H_ */

--- a/libc/include/aarch64-macos-gnu/ar.h
+++ b/libc/include/aarch64-macos-gnu/ar.h
@@ -1,0 +1,67 @@
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Hugh Smith at The University of Guelph.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ar.h	8.2 (Berkeley) 1/21/94
+ */
+
+#ifndef _AR_H_
+#define	_AR_H_
+
+/* Pre-4BSD archives had these magic numbers in them. */
+#define	OARMAG1	0177555
+#define	OARMAG2	0177545
+
+#define	ARMAG		"!<arch>\n"	/* ar "magic number" */
+#define	SARMAG		8		/* strlen(ARMAG); */
+
+#define	AR_EFMT1	"#1/"		/* extended format #1 */
+
+struct ar_hdr {
+	char ar_name[16];		/* name */
+	char ar_date[12];		/* modification time */
+	char ar_uid[6];			/* user id */
+	char ar_gid[6];			/* group id */
+	char ar_mode[8];		/* octal file permissions */
+	char ar_size[10];		/* size in bytes */
+#define	ARFMAG	"`\n"
+	char ar_fmag[2];		/* consistency check */
+};
+
+#endif /* !_AR_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/arch.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/arch.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#ifndef _MACH_O_ARCH_H_
+#define _MACH_O_ARCH_H_
+/*
+ * Copyright (c) 1997 Apple Computer, Inc.
+ *
+ * Functions that deal with information about architectures.
+ *
+ */
+
+#include <stdint.h>
+#include <mach/machine.h>
+#include <architecture/byte_order.h>
+
+/* The NXArchInfo structs contain the architectures symbolic name
+ * (such as "ppc"), its CPU type and CPU subtype as defined in
+ * mach/machine.h, the byte order for the architecture, and a
+ * describing string (such as "PowerPC").
+ * There will both be entries for specific CPUs (such as ppc604e) as
+ * well as generic "family" entries (such as ppc).
+ */
+typedef struct {
+    const char *name;
+    cpu_type_t cputype;
+    cpu_subtype_t cpusubtype;
+    enum NXByteOrder byteorder;
+    const char *description;
+} NXArchInfo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* NXGetAllArchInfos() returns a pointer to an array of all known
+ * NXArchInfo structures.  The last NXArchInfo is marked by a NULL name.
+ */
+extern const NXArchInfo *NXGetAllArchInfos(void);
+
+/* NXGetLocalArchInfo() returns the NXArchInfo for the local host, or NULL
+ * if none is known. 
+ */
+extern const NXArchInfo *NXGetLocalArchInfo(void);
+
+/* NXGetArchInfoFromName() and NXGetArchInfoFromCpuType() return the
+ * NXArchInfo from the architecture's name or cputype/cpusubtype
+ * combination.  A cpusubtype of CPU_SUBTYPE_MULTIPLE can be used
+ * to request the most general NXArchInfo known for the given cputype.
+ * NULL is returned if no matching NXArchInfo can be found.
+ */
+extern const NXArchInfo *NXGetArchInfoFromName(const char *name);
+extern const NXArchInfo *NXGetArchInfoFromCpuType(cpu_type_t cputype,
+						  cpu_subtype_t cpusubtype);
+
+/* The above interfaces that return pointers to NXArchInfo structs in normal
+ * cases returns a pointer from the array returned in NXGetAllArchInfos().
+ * In some cases when the cputype is CPU_TYPE_I386 or CPU_TYPE_POWERPC it will
+ * retun malloc(3)'ed NXArchInfo struct which contains a string in the
+ * description field also a malloc(3)'ed pointer.  To allow programs not to
+ * leak memory they can call NXFreeArchInfo() on pointers returned from the
+ * above interfaces.  Since this is a new API on older systems can use the
+ * code below.  Going forward the above interfaces will only return pointers
+ * from the array returned in NXGetAllArchInfos().
+ */
+extern void NXFreeArchInfo(const NXArchInfo *x);
+
+/* The code that can be used for NXFreeArchInfo() when it is not available is:
+ *
+ *	static void NXFreeArchInfo(
+ *	const NXArchInfo *x)
+ *	{
+ *	    const NXArchInfo *p;
+ *	
+ *	        p = NXGetAllArchInfos();
+ *	        while(p->name != NULL){
+ *	            if(x == p)
+ *	                return;
+ *	            p++;
+ *	        }
+ *	        free((char *)x->description);
+ *	        free((NXArchInfo *)x);
+ *	}
+ */
+
+/* NXFindBestFatArch() is passed a cputype and cpusubtype and a set of
+ * fat_arch structs and selects the best one that matches (if any) and returns
+ * a pointer to that fat_arch struct (or NULL).  The fat_arch structs must be
+ * in the host byte order and correct such that the fat_archs really points to
+ * enough memory for nfat_arch structs.  It is possible that this routine could
+ * fail if new cputypes or cpusubtypes are added and an old version of this
+ * routine is used.  But if there is an exact match between the cputype and
+ * cpusubtype and one of the fat_arch structs this routine will always succeed.
+ */
+extern struct fat_arch *NXFindBestFatArch(cpu_type_t cputype,
+					  cpu_subtype_t cpusubtype,
+					  struct fat_arch *fat_archs,
+					  uint32_t nfat_archs);
+
+/* NXFindBestFatArch_64() is passed a cputype and cpusubtype and a set of
+ * fat_arch_64 structs and selects the best one that matches (if any) and
+ * returns a pointer to that fat_arch_64 struct (or NULL).  The fat_arch_64
+ * structs must be in the host byte order and correct such that the fat_archs64
+ * really points to enough memory for nfat_arch structs.  It is possible that
+ * this routine could fail if new cputypes or cpusubtypes are added and an old
+ * version of this routine is used.  But if there is an exact match between the
+ * cputype and cpusubtype and one of the fat_arch_64 structs this routine will
+ * always succeed.
+ */
+extern struct fat_arch_64 *NXFindBestFatArch_64(cpu_type_t cputype,
+					        cpu_subtype_t cpusubtype,
+					        struct fat_arch_64 *fat_archs64,
+					        uint32_t nfat_archs);
+
+/* NXCombineCpuSubtypes() returns the resulting cpusubtype when combining two
+ * different cpusubtypes for the specified cputype.  If the two cpusubtypes
+ * can't be combined (the specific subtypes are mutually exclusive) -1 is
+ * returned indicating it is an error to combine them.  This can also fail and
+ * return -1 if new cputypes or cpusubtypes are added and an old version of
+ * this routine is used.  But if the cpusubtypes are the same they can always
+ * be combined and this routine will return the cpusubtype pass in.
+ */
+extern cpu_subtype_t NXCombineCpuSubtypes(cpu_type_t cputype,
+					  cpu_subtype_t cpusubtype1,
+					  cpu_subtype_t cpusubtype2);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* _MACH_O_ARCH_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/arm64/reloc.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/arm64/reloc.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+
+#ifndef _MACHO_ARM64_RELOC_H_
+#define _MACHO_ARM64_RELOC_H_
+
+/*
+ * Relocation types used in the arm64 implementation.
+ */
+enum reloc_type_arm64
+{
+    ARM64_RELOC_UNSIGNED,	  // for pointers
+    ARM64_RELOC_SUBTRACTOR,       // must be followed by a ARM64_RELOC_UNSIGNED
+    ARM64_RELOC_BRANCH26,         // a B/BL instruction with 26-bit displacement
+    ARM64_RELOC_PAGE21,           // pc-rel distance to page of target
+    ARM64_RELOC_PAGEOFF12,        // offset within page, scaled by r_length
+    ARM64_RELOC_GOT_LOAD_PAGE21,  // pc-rel distance to page of GOT slot
+    ARM64_RELOC_GOT_LOAD_PAGEOFF12, // offset within page of GOT slot,
+                                    //  scaled by r_length
+    ARM64_RELOC_POINTER_TO_GOT,   // for pointers to GOT slots
+    ARM64_RELOC_TLVP_LOAD_PAGE21, // pc-rel distance to page of TLVP slot
+    ARM64_RELOC_TLVP_LOAD_PAGEOFF12, // offset within page of TLVP slot,
+                                     //  scaled by r_length
+    ARM64_RELOC_ADDEND,		  // must be followed by PAGE21 or PAGEOFF12
+
+    // An arm64e authenticated pointer.
+    //
+    // Represents a pointer to a symbol (like ARM64_RELOC_UNSIGNED).
+    // Additionally, the resulting pointer is signed.  The signature is
+    // specified in the target location: the addend is restricted to the lower
+    // 32 bits (instead of the full 64 bits for ARM64_RELOC_UNSIGNED):
+    //
+    //   |63|62|61-51|50-49|  48  |47     -     32|31  -  0|
+    //   | 1| 0|  0  | key | addr | discriminator | addend |
+    //
+    // The key is one of:
+    //   IA: 00 IB: 01
+    //   DA: 10 DB: 11
+    //
+    // The discriminator field is used as extra signature diversification.
+    //
+    // The addr field indicates whether the target address should be blended
+    // into the discriminator.
+    //
+    ARM64_RELOC_AUTHENTICATED_POINTER,
+};
+
+#endif /* #ifndef _MACHO_ARM64_RELOC_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/compact_unwind_encoding.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/compact_unwind_encoding.h
@@ -1,0 +1,533 @@
+//===------------------ mach-o/compact_unwind_encoding.h ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// Darwin's alternative to DWARF based unwind encodings.
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef __COMPACT_UNWIND_ENCODING__
+#define __COMPACT_UNWIND_ENCODING__
+
+#include <stdint.h>
+
+//
+// Compilers can emit standard DWARF FDEs in the __TEXT,__eh_frame section
+// of object files. Or compilers can emit compact unwind information in
+// the __LD,__compact_unwind section.
+//
+// When the linker creates a final linked image, it will create a
+// __TEXT,__unwind_info section.  This section is a small and fast way for the
+// runtime to access unwind info for any given function.  If the compiler
+// emitted compact unwind info for the function, that compact unwind info will
+// be encoded in the __TEXT,__unwind_info section. If the compiler emitted
+// DWARF unwind info, the __TEXT,__unwind_info section will contain the offset
+// of the FDE in the __TEXT,__eh_frame section in the final linked image.
+//
+// Note: Previously, the linker would transform some DWARF unwind infos into
+//       compact unwind info.  But that is fragile and no longer done.
+
+
+//
+// The compact unwind endoding is a 32-bit value which encoded in an
+// architecture specific way, which registers to restore from where, and how
+// to unwind out of the function.
+//
+typedef uint32_t compact_unwind_encoding_t;
+
+
+// architecture independent bits
+enum {
+    UNWIND_IS_NOT_FUNCTION_START           = 0x80000000,
+    UNWIND_HAS_LSDA                        = 0x40000000,
+    UNWIND_PERSONALITY_MASK                = 0x30000000,
+};
+
+
+
+
+//
+// x86
+//
+// 1-bit: start
+// 1-bit: has lsda
+// 2-bit: personality index
+//
+// 4-bits: 0=old, 1=ebp based, 2=stack-imm, 3=stack-ind, 4=DWARF
+//  ebp based:
+//        15-bits (5*3-bits per reg) register permutation
+//        8-bits for stack offset
+//  frameless:
+//        8-bits stack size
+//        3-bits stack adjust
+//        3-bits register count
+//        10-bits register permutation
+//
+enum {
+    UNWIND_X86_MODE_MASK                         = 0x0F000000,
+    UNWIND_X86_MODE_EBP_FRAME                    = 0x01000000,
+    UNWIND_X86_MODE_STACK_IMMD                   = 0x02000000,
+    UNWIND_X86_MODE_STACK_IND                    = 0x03000000,
+    UNWIND_X86_MODE_DWARF                        = 0x04000000,
+
+    UNWIND_X86_EBP_FRAME_REGISTERS               = 0x00007FFF,
+    UNWIND_X86_EBP_FRAME_OFFSET                  = 0x00FF0000,
+
+    UNWIND_X86_FRAMELESS_STACK_SIZE              = 0x00FF0000,
+    UNWIND_X86_FRAMELESS_STACK_ADJUST            = 0x0000E000,
+    UNWIND_X86_FRAMELESS_STACK_REG_COUNT         = 0x00001C00,
+    UNWIND_X86_FRAMELESS_STACK_REG_PERMUTATION   = 0x000003FF,
+
+    UNWIND_X86_DWARF_SECTION_OFFSET              = 0x00FFFFFF,
+};
+
+enum {
+    UNWIND_X86_REG_NONE     = 0,
+    UNWIND_X86_REG_EBX      = 1,
+    UNWIND_X86_REG_ECX      = 2,
+    UNWIND_X86_REG_EDX      = 3,
+    UNWIND_X86_REG_EDI      = 4,
+    UNWIND_X86_REG_ESI      = 5,
+    UNWIND_X86_REG_EBP      = 6,
+};
+
+//
+// For x86 there are four modes for the compact unwind encoding:
+// UNWIND_X86_MODE_EBP_FRAME:
+//    EBP based frame where EBP is push on stack immediately after return address,
+//    then ESP is moved to EBP. Thus, to unwind ESP is restored with the current
+//    EPB value, then EBP is restored by popping off the stack, and the return
+//    is done by popping the stack once more into the pc.
+//    All non-volatile registers that need to be restored must have been saved
+//    in a small range in the stack that starts EBP-4 to EBP-1020.  The offset/4
+//    is encoded in the UNWIND_X86_EBP_FRAME_OFFSET bits.  The registers saved
+//    are encoded in the UNWIND_X86_EBP_FRAME_REGISTERS bits as five 3-bit entries.
+//    Each entry contains which register to restore.
+// UNWIND_X86_MODE_STACK_IMMD:
+//    A "frameless" (EBP not used as frame pointer) function with a small 
+//    constant stack size.  To return, a constant (encoded in the compact
+//    unwind encoding) is added to the ESP. Then the return is done by
+//    popping the stack into the pc.
+//    All non-volatile registers that need to be restored must have been saved
+//    on the stack immediately after the return address.  The stack_size/4 is
+//    encoded in the UNWIND_X86_FRAMELESS_STACK_SIZE (max stack size is 1024).
+//    The number of registers saved is encoded in UNWIND_X86_FRAMELESS_STACK_REG_COUNT.
+//    UNWIND_X86_FRAMELESS_STACK_REG_PERMUTATION constains which registers were
+//    saved and their order.
+// UNWIND_X86_MODE_STACK_IND:
+//    A "frameless" (EBP not used as frame pointer) function large constant 
+//    stack size.  This case is like the previous, except the stack size is too
+//    large to encode in the compact unwind encoding.  Instead it requires that 
+//    the function contains "subl $nnnnnnnn,ESP" in its prolog.  The compact 
+//    encoding contains the offset to the nnnnnnnn value in the function in
+//    UNWIND_X86_FRAMELESS_STACK_SIZE.  
+// UNWIND_X86_MODE_DWARF:
+//    No compact unwind encoding is available.  Instead the low 24-bits of the
+//    compact encoding is the offset of the DWARF FDE in the __eh_frame section.
+//    This mode is never used in object files.  It is only generated by the 
+//    linker in final linked images which have only DWARF unwind info for a
+//    function.
+//
+// The permutation encoding is a Lehmer code sequence encoded into a
+// single variable-base number so we can encode the ordering of up to
+// six registers in a 10-bit space.
+//
+// The following is the algorithm used to create the permutation encoding used
+// with frameless stacks.  It is passed the number of registers to be saved and
+// an array of the register numbers saved.
+//
+//uint32_t permute_encode(uint32_t registerCount, const uint32_t registers[6])
+//{
+//    uint32_t renumregs[6];
+//    for (int i=6-registerCount; i < 6; ++i) {
+//        int countless = 0;
+//        for (int j=6-registerCount; j < i; ++j) {
+//            if ( registers[j] < registers[i] )
+//                ++countless;
+//        }
+//        renumregs[i] = registers[i] - countless -1;
+//    }
+//    uint32_t permutationEncoding = 0;
+//    switch ( registerCount ) {
+//        case 6:
+//            permutationEncoding |= (120*renumregs[0] + 24*renumregs[1]
+//                                    + 6*renumregs[2] + 2*renumregs[3]
+//                                      + renumregs[4]);
+//            break;
+//        case 5:
+//            permutationEncoding |= (120*renumregs[1] + 24*renumregs[2]
+//                                    + 6*renumregs[3] + 2*renumregs[4]
+//                                      + renumregs[5]);
+//            break;
+//        case 4:
+//            permutationEncoding |= (60*renumregs[2] + 12*renumregs[3]
+//                                   + 3*renumregs[4] + renumregs[5]);
+//            break;
+//        case 3:
+//            permutationEncoding |= (20*renumregs[3] + 4*renumregs[4]
+//                                     + renumregs[5]);
+//            break;
+//        case 2:
+//            permutationEncoding |= (5*renumregs[4] + renumregs[5]);
+//            break;
+//        case 1:
+//            permutationEncoding |= (renumregs[5]);
+//            break;
+//    }
+//    return permutationEncoding;
+//}
+//
+
+
+
+
+//
+// x86_64
+//
+// 1-bit: start
+// 1-bit: has lsda
+// 2-bit: personality index
+//
+// 4-bits: 0=old, 1=rbp based, 2=stack-imm, 3=stack-ind, 4=DWARF
+//  rbp based:
+//        15-bits (5*3-bits per reg) register permutation
+//        8-bits for stack offset
+//  frameless:
+//        8-bits stack size
+//        3-bits stack adjust
+//        3-bits register count
+//        10-bits register permutation
+//
+enum {
+    UNWIND_X86_64_MODE_MASK                         = 0x0F000000,
+    UNWIND_X86_64_MODE_RBP_FRAME                    = 0x01000000,
+    UNWIND_X86_64_MODE_STACK_IMMD                   = 0x02000000,
+    UNWIND_X86_64_MODE_STACK_IND                    = 0x03000000,
+    UNWIND_X86_64_MODE_DWARF                        = 0x04000000,
+
+    UNWIND_X86_64_RBP_FRAME_REGISTERS               = 0x00007FFF,
+    UNWIND_X86_64_RBP_FRAME_OFFSET                  = 0x00FF0000,
+
+    UNWIND_X86_64_FRAMELESS_STACK_SIZE              = 0x00FF0000,
+    UNWIND_X86_64_FRAMELESS_STACK_ADJUST            = 0x0000E000,
+    UNWIND_X86_64_FRAMELESS_STACK_REG_COUNT         = 0x00001C00,
+    UNWIND_X86_64_FRAMELESS_STACK_REG_PERMUTATION   = 0x000003FF,
+
+    UNWIND_X86_64_DWARF_SECTION_OFFSET              = 0x00FFFFFF,
+};
+
+enum {
+    UNWIND_X86_64_REG_NONE       = 0,
+    UNWIND_X86_64_REG_RBX        = 1,
+    UNWIND_X86_64_REG_R12        = 2,
+    UNWIND_X86_64_REG_R13        = 3,
+    UNWIND_X86_64_REG_R14        = 4,
+    UNWIND_X86_64_REG_R15        = 5,
+    UNWIND_X86_64_REG_RBP        = 6,
+};
+//
+// For x86_64 there are four modes for the compact unwind encoding:
+// UNWIND_X86_64_MODE_RBP_FRAME:
+//    RBP based frame where RBP is push on stack immediately after return address,
+//    then RSP is moved to RBP. Thus, to unwind RSP is restored with the current 
+//    EPB value, then RBP is restored by popping off the stack, and the return 
+//    is done by popping the stack once more into the pc.
+//    All non-volatile registers that need to be restored must have been saved
+//    in a small range in the stack that starts RBP-8 to RBP-2040.  The offset/8 
+//    is encoded in the UNWIND_X86_64_RBP_FRAME_OFFSET bits.  The registers saved
+//    are encoded in the UNWIND_X86_64_RBP_FRAME_REGISTERS bits as five 3-bit entries.
+//    Each entry contains which register to restore.  
+// UNWIND_X86_64_MODE_STACK_IMMD:
+//    A "frameless" (RBP not used as frame pointer) function with a small 
+//    constant stack size.  To return, a constant (encoded in the compact 
+//    unwind encoding) is added to the RSP. Then the return is done by 
+//    popping the stack into the pc.
+//    All non-volatile registers that need to be restored must have been saved
+//    on the stack immediately after the return address.  The stack_size/8 is
+//    encoded in the UNWIND_X86_64_FRAMELESS_STACK_SIZE (max stack size is 2048).
+//    The number of registers saved is encoded in UNWIND_X86_64_FRAMELESS_STACK_REG_COUNT.
+//    UNWIND_X86_64_FRAMELESS_STACK_REG_PERMUTATION constains which registers were
+//    saved and their order.  
+// UNWIND_X86_64_MODE_STACK_IND:
+//    A "frameless" (RBP not used as frame pointer) function large constant 
+//    stack size.  This case is like the previous, except the stack size is too
+//    large to encode in the compact unwind encoding.  Instead it requires that 
+//    the function contains "subq $nnnnnnnn,RSP" in its prolog.  The compact 
+//    encoding contains the offset to the nnnnnnnn value in the function in
+//    UNWIND_X86_64_FRAMELESS_STACK_SIZE.  
+// UNWIND_X86_64_MODE_DWARF:
+//    No compact unwind encoding is available.  Instead the low 24-bits of the
+//    compact encoding is the offset of the DWARF FDE in the __eh_frame section.
+//    This mode is never used in object files.  It is only generated by the 
+//    linker in final linked images which have only DWARF unwind info for a
+//    function.
+//
+
+
+// ARM64
+//
+// 1-bit: start
+// 1-bit: has lsda
+// 2-bit: personality index
+//
+// 4-bits: 4=frame-based, 3=DWARF, 2=frameless
+//  frameless:
+//        12-bits of stack size
+//  frame-based:
+//        4-bits D reg pairs saved
+//        5-bits X reg pairs saved
+//  DWARF:
+//        24-bits offset of DWARF FDE in __eh_frame section
+//
+enum {
+    UNWIND_ARM64_MODE_MASK                     = 0x0F000000,
+    UNWIND_ARM64_MODE_FRAMELESS                = 0x02000000,
+    UNWIND_ARM64_MODE_DWARF                    = 0x03000000,
+    UNWIND_ARM64_MODE_FRAME                    = 0x04000000,
+
+    UNWIND_ARM64_FRAME_X19_X20_PAIR            = 0x00000001,
+    UNWIND_ARM64_FRAME_X21_X22_PAIR            = 0x00000002,
+    UNWIND_ARM64_FRAME_X23_X24_PAIR            = 0x00000004,
+    UNWIND_ARM64_FRAME_X25_X26_PAIR            = 0x00000008,
+    UNWIND_ARM64_FRAME_X27_X28_PAIR            = 0x00000010,
+    UNWIND_ARM64_FRAME_D8_D9_PAIR              = 0x00000100,
+    UNWIND_ARM64_FRAME_D10_D11_PAIR            = 0x00000200,
+    UNWIND_ARM64_FRAME_D12_D13_PAIR            = 0x00000400,
+    UNWIND_ARM64_FRAME_D14_D15_PAIR            = 0x00000800,
+
+    UNWIND_ARM64_FRAMELESS_STACK_SIZE_MASK     = 0x00FFF000,
+    UNWIND_ARM64_DWARF_SECTION_OFFSET          = 0x00FFFFFF,
+};
+// For arm64 there are three modes for the compact unwind encoding:
+// UNWIND_ARM64_MODE_FRAME:
+//    This is a standard arm64 prolog where FP/LR are immediately pushed on the
+//    stack, then SP is copied to FP. If there are any non-volatile registers
+//    saved, then are copied into the stack frame in pairs in a contiguous
+//    range right below the saved FP/LR pair.  Any subset of the five X pairs 
+//    and four D pairs can be saved, but the memory layout must be in register
+//    number order.  
+// UNWIND_ARM64_MODE_FRAMELESS:
+//    A "frameless" leaf function, where FP/LR are not saved. The return address 
+//    remains in LR throughout the function. If any non-volatile registers
+//    are saved, they must be pushed onto the stack before any stack space is
+//    allocated for local variables.  The stack sized (including any saved
+//    non-volatile registers) divided by 16 is encoded in the bits 
+//    UNWIND_ARM64_FRAMELESS_STACK_SIZE_MASK.
+// UNWIND_ARM64_MODE_DWARF:
+//    No compact unwind encoding is available.  Instead the low 24-bits of the
+//    compact encoding is the offset of the DWARF FDE in the __eh_frame section.
+//    This mode is never used in object files.  It is only generated by the 
+//    linker in final linked images which have only DWARF unwind info for a
+//    function.
+//
+
+
+#ifndef __OPEN_SOURCE__
+//
+// armv7k
+//
+// 1-bit: start
+// 1-bit: has lsda
+// 2-bit: personality index
+//
+// 4-bits: 1=frame, 2=frame+dregs, 4=dwarf
+//
+enum {
+  UNWIND_ARM_MODE_MASK                         = 0x0F000000,
+  UNWIND_ARM_MODE_FRAME                        = 0x01000000,
+  UNWIND_ARM_MODE_FRAME_D                      = 0x02000000,
+  UNWIND_ARM_MODE_DWARF                        = 0x04000000,
+
+  UNWIND_ARM_FRAME_STACK_ADJUST_MASK           = 0x00C00000,
+
+  UNWIND_ARM_FRAME_FIRST_PUSH_R4               = 0x00000001,
+  UNWIND_ARM_FRAME_FIRST_PUSH_R5               = 0x00000002,
+  UNWIND_ARM_FRAME_FIRST_PUSH_R6               = 0x00000004,
+
+  UNWIND_ARM_FRAME_SECOND_PUSH_R8              = 0x00000008,
+  UNWIND_ARM_FRAME_SECOND_PUSH_R9              = 0x00000010,
+  UNWIND_ARM_FRAME_SECOND_PUSH_R10             = 0x00000020,
+  UNWIND_ARM_FRAME_SECOND_PUSH_R11             = 0x00000040,
+  UNWIND_ARM_FRAME_SECOND_PUSH_R12             = 0x00000080,
+
+  UNWIND_ARM_FRAME_D_REG_COUNT_MASK            = 0x00000700,
+
+  UNWIND_ARM_DWARF_SECTION_OFFSET              = 0x00FFFFFF,
+};
+// For armv7k there are three modes for the compact unwind encoding:
+// UNWIND_ARM_MODE_FRAME:
+//    This is a standard arm prolog where lr/r7 are immediately pushed on the
+//    stack.  As part of that first push r4, r5, or r6 can be also pushed
+//    and if so the FIRST_PUSH bit is set in the compact unwind. Additionally
+//    there can be a second push multiple which can save r8 through r12.
+//    If that is used, the registers saved is recorded with a SECOND_PUSH bit.
+//    Lastly, for var-args support, the prolog may save r1, r2, r3 to the
+//    stack before the frame push.  If that is done the STACK_ADJUST_MASK
+//    records that the stack pointer must be adjust (e.g 0x00800000 means
+//    the stack pointer was adjusted 8 bytes down and the unwinder would
+//    need to add back 8 bytes to SP when unwinding through this function.
+// UNWIND_ARM_MODE_FRAME_D:
+//    This is the same as UNWIND_ARM_MODE_FRAME, except that additionally
+//    some D registers were saved.  The D_REG_COUNT_MASK contains which
+//    set if D registers were saved and where.  There are currently 8 (0-7)
+//    possible D register save patterns supported.
+// UNWIND_ARM_MODE_DWARF:
+//    No compact unwind encoding is available.  Instead the low 24-bits of the
+//    compact encoding is the offset of the dwarf FDE in the __eh_frame section.
+//    The offset only exists in final linked images. It is zero in object files.
+#endif
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Relocatable Object Files: __LD,__compact_unwind
+//
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// A compiler can generated compact unwind information for a function by adding
+// a "row" to the __LD,__compact_unwind section.  This section has the 
+// S_ATTR_DEBUG bit set, so the section will be ignored by older linkers. 
+// It is removed by the new linker, so never ends up in final executables. 
+// This section is a table, initially with one row per function (that needs 
+// unwind info).  The table columns and some conceptual entries are:
+//
+//     range-start               pointer to start of function/range
+//     range-length              
+//     compact-unwind-encoding   32-bit encoding  
+//     personality-function      or zero if no personality function
+//     lsda                      or zero if no LSDA data
+//
+// The length and encoding fields are 32-bits.  The other are all pointer sized. 
+//
+// In x86_64 assembly, these entry would look like:
+//
+//     .section __LD,__compact_unwind,regular,debug
+//
+//     #compact unwind for _foo
+//     .quad    _foo
+//     .set     L1,LfooEnd-_foo
+//     .long    L1
+//     .long    0x01010001
+//     .quad    0
+//     .quad    0
+//
+//     #compact unwind for _bar
+//     .quad    _bar
+//     .set     L2,LbarEnd-_bar
+//     .long    L2
+//     .long    0x01020011
+//     .quad    __gxx_personality
+//     .quad    except_tab1
+//
+//
+// Notes: There is no need for any labels in the the __compact_unwind section.  
+//        The use of the .set directive is to force the evaluation of the 
+//        range-length at assembly time, instead of generating relocations.
+//
+// To support future compiler optimizations where which non-volatile registers 
+// are saved changes within a function (e.g. delay saving non-volatiles until
+// necessary), there can by multiple lines in the __compact_unwind table for one
+// function, each with a different (non-overlapping) range and each with 
+// different compact unwind encodings that correspond to the non-volatiles 
+// saved at that range of the function.
+//
+// If a particular function is so wacky that there is no compact unwind way
+// to encode it, then the compiler can emit traditional DWARF unwind info.  
+// The runtime will use which ever is available.
+//
+// Runtime support for compact unwind encodings are only available on 10.6 
+// and later.  So, the compiler should not generate it when targeting pre-10.6. 
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Final Linked Images: __TEXT,__unwind_info
+//
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// The __TEXT,__unwind_info section is laid out for an efficient two level lookup.
+// The header of the section contains a coarse index that maps function address
+// to the page (4096 byte block) containing the unwind info for that function.  
+//
+
+#define UNWIND_SECTION_VERSION 1
+struct unwind_info_section_header
+{
+    uint32_t    version;            // UNWIND_SECTION_VERSION
+    uint32_t    commonEncodingsArraySectionOffset;
+    uint32_t    commonEncodingsArrayCount;
+    uint32_t    personalityArraySectionOffset;
+    uint32_t    personalityArrayCount;
+    uint32_t    indexSectionOffset;
+    uint32_t    indexCount;
+    // compact_unwind_encoding_t[]
+    // uint32_t personalities[]
+    // unwind_info_section_header_index_entry[]
+    // unwind_info_section_header_lsda_index_entry[]
+};
+
+struct unwind_info_section_header_index_entry
+{
+    uint32_t        functionOffset;
+    uint32_t        secondLevelPagesSectionOffset;  // section offset to start of regular or compress page
+    uint32_t        lsdaIndexArraySectionOffset;    // section offset to start of lsda_index array for this range
+};
+
+struct unwind_info_section_header_lsda_index_entry
+{
+    uint32_t        functionOffset;
+    uint32_t        lsdaOffset;
+};
+
+//
+// There are two kinds of second level index pages: regular and compressed.
+// A compressed page can hold up to 1021 entries, but it cannot be used
+// if too many different encoding types are used.  The regular page holds
+// 511 entries.
+//
+
+struct unwind_info_regular_second_level_entry
+{
+    uint32_t                    functionOffset;
+    compact_unwind_encoding_t    encoding;
+};
+
+#define UNWIND_SECOND_LEVEL_REGULAR 2
+struct unwind_info_regular_second_level_page_header
+{
+    uint32_t    kind;    // UNWIND_SECOND_LEVEL_REGULAR
+    uint16_t    entryPageOffset;
+    uint16_t    entryCount;
+    // entry array
+};
+
+#define UNWIND_SECOND_LEVEL_COMPRESSED 3
+struct unwind_info_compressed_second_level_page_header
+{
+    uint32_t    kind;    // UNWIND_SECOND_LEVEL_COMPRESSED
+    uint16_t    entryPageOffset;
+    uint16_t    entryCount;
+    uint16_t    encodingsPageOffset;
+    uint16_t    encodingsCount;
+    // 32-bit entry array
+    // encodings array
+};
+
+#define UNWIND_INFO_COMPRESSED_ENTRY_FUNC_OFFSET(entry)            (entry & 0x00FFFFFF)
+#define UNWIND_INFO_COMPRESSED_ENTRY_ENCODING_INDEX(entry)        ((entry >> 24) & 0xFF)
+
+
+
+#endif
+

--- a/libc/include/aarch64-macos-gnu/mach-o/fat.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/fat.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016 Apple, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#ifndef _MACH_O_FAT_H_
+#define _MACH_O_FAT_H_
+/*
+ * This header file describes the structures of the file format for "fat"
+ * architecture specific file (wrapper design).  At the begining of the file
+ * there is one fat_header structure followed by a number of fat_arch
+ * structures.  For each architecture in the file, specified by a pair of
+ * cputype and cpusubtype, the fat_header describes the file offset, file
+ * size and alignment in the file of the architecture specific member.
+ * The padded bytes in the file to place each member on it's specific alignment
+ * are defined to be read as zeros and can be left as "holes" if the file system
+ * can support them as long as they read as zeros.
+ *
+ * All structures defined here are always written and read to/from disk
+ * in big-endian order.
+ */
+
+/*
+ * <mach/machine.h> is needed here for the cpu_type_t and cpu_subtype_t types
+ * and contains the constants for the possible values of these types.
+ */
+#include <stdint.h>
+#include <mach/machine.h>
+#include <architecture/byte_order.h>
+
+#define FAT_MAGIC	0xcafebabe
+#define FAT_CIGAM	0xbebafeca	/* NXSwapLong(FAT_MAGIC) */
+
+struct fat_header {
+	uint32_t	magic;		/* FAT_MAGIC or FAT_MAGIC_64 */
+	uint32_t	nfat_arch;	/* number of structs that follow */
+};
+
+struct fat_arch {
+	cpu_type_t	cputype;	/* cpu specifier (int) */
+	cpu_subtype_t	cpusubtype;	/* machine specifier (int) */
+	uint32_t	offset;		/* file offset to this object file */
+	uint32_t	size;		/* size of this object file */
+	uint32_t	align;		/* alignment as a power of 2 */
+};
+
+/*
+ * The support for the 64-bit fat file format described here is a work in
+ * progress and not yet fully supported in all the Apple Developer Tools.
+ *
+ * When a slice is greater than 4mb or an offset to a slice is greater than 4mb
+ * then the 64-bit fat file format is used.
+ */
+#define FAT_MAGIC_64	0xcafebabf
+#define FAT_CIGAM_64	0xbfbafeca	/* NXSwapLong(FAT_MAGIC_64) */
+
+struct fat_arch_64 {
+	cpu_type_t	cputype;	/* cpu specifier (int) */
+	cpu_subtype_t	cpusubtype;	/* machine specifier (int) */
+	uint64_t	offset;		/* file offset to this object file */
+	uint64_t	size;		/* size of this object file */
+	uint32_t	align;		/* alignment as a power of 2 */
+	uint32_t	reserved;	/* reserved */
+};
+
+#endif /* _MACH_O_FAT_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/nlist.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/nlist.h
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 1999-2003 Apple Computer, Inc.  All Rights Reserved.
+ * 
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#ifndef _MACHO_NLIST_H_
+#define _MACHO_NLIST_H_
+/*	$NetBSD: nlist.h,v 1.5 1994/10/26 00:56:11 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)nlist.h	8.2 (Berkeley) 1/21/94
+ */
+#include <stdint.h>
+
+/*
+ * Format of a symbol table entry of a Mach-O file for 32-bit architectures.
+ * Modified from the BSD format.  The modifications from the original format
+ * were changing n_other (an unused field) to n_sect and the addition of the
+ * N_SECT type.  These modifications are required to support symbols in a larger
+ * number of sections not just the three sections (text, data and bss) in a BSD
+ * file.
+ */
+struct nlist {
+	union {
+#ifndef __LP64__
+		char *n_name;	/* for use when in-core */
+#endif
+		uint32_t n_strx;	/* index into the string table */
+	} n_un;
+	uint8_t n_type;		/* type flag, see below */
+	uint8_t n_sect;		/* section number or NO_SECT */
+	int16_t n_desc;		/* see <mach-o/stab.h> */
+	uint32_t n_value;	/* value of this symbol (or stab offset) */
+};
+
+/*
+ * This is the symbol table entry structure for 64-bit architectures.
+ */
+struct nlist_64 {
+    union {
+        uint32_t  n_strx; /* index into the string table */
+    } n_un;
+    uint8_t n_type;        /* type flag, see below */
+    uint8_t n_sect;        /* section number or NO_SECT */
+    uint16_t n_desc;       /* see <mach-o/stab.h> */
+    uint64_t n_value;      /* value of this symbol (or stab offset) */
+};
+
+/*
+ * Symbols with a index into the string table of zero (n_un.n_strx == 0) are
+ * defined to have a null, "", name.  Therefore all string indexes to non null
+ * names must not have a zero string index.  This is bit historical information
+ * that has never been well documented.
+ */
+
+/*
+ * The n_type field really contains four fields:
+ *	unsigned char N_STAB:3,
+ *		      N_PEXT:1,
+ *		      N_TYPE:3,
+ *		      N_EXT:1;
+ * which are used via the following masks.
+ */
+#define	N_STAB	0xe0  /* if any of these bits set, a symbolic debugging entry */
+#define	N_PEXT	0x10  /* private external symbol bit */
+#define	N_TYPE	0x0e  /* mask for the type bits */
+#define	N_EXT	0x01  /* external symbol bit, set for external symbols */
+
+/*
+ * Only symbolic debugging entries have some of the N_STAB bits set and if any
+ * of these bits are set then it is a symbolic debugging entry (a stab).  In
+ * which case then the values of the n_type field (the entire field) are given
+ * in <mach-o/stab.h>
+ */
+
+/*
+ * Values for N_TYPE bits of the n_type field.
+ */
+#define	N_UNDF	0x0		/* undefined, n_sect == NO_SECT */
+#define	N_ABS	0x2		/* absolute, n_sect == NO_SECT */
+#define	N_SECT	0xe		/* defined in section number n_sect */
+#define	N_PBUD	0xc		/* prebound undefined (defined in a dylib) */
+#define N_INDR	0xa		/* indirect */
+
+/* 
+ * If the type is N_INDR then the symbol is defined to be the same as another
+ * symbol.  In this case the n_value field is an index into the string table
+ * of the other symbol's name.  When the other symbol is defined then they both
+ * take on the defined type and value.
+ */
+
+/*
+ * If the type is N_SECT then the n_sect field contains an ordinal of the
+ * section the symbol is defined in.  The sections are numbered from 1 and 
+ * refer to sections in order they appear in the load commands for the file
+ * they are in.  This means the same ordinal may very well refer to different
+ * sections in different files.
+ *
+ * The n_value field for all symbol table entries (including N_STAB's) gets
+ * updated by the link editor based on the value of it's n_sect field and where
+ * the section n_sect references gets relocated.  If the value of the n_sect 
+ * field is NO_SECT then it's n_value field is not changed by the link editor.
+ */
+#define	NO_SECT		0	/* symbol is not in any section */
+#define MAX_SECT	255	/* 1 thru 255 inclusive */
+
+/*
+ * Common symbols are represented by undefined (N_UNDF) external (N_EXT) types
+ * who's values (n_value) are non-zero.  In which case the value of the n_value
+ * field is the size (in bytes) of the common symbol.  The n_sect field is set
+ * to NO_SECT.  The alignment of a common symbol may be set as a power of 2
+ * between 2^1 and 2^15 as part of the n_desc field using the macros below. If
+ * the alignment is not set (a value of zero) then natural alignment based on
+ * the size is used.
+ */
+#define GET_COMM_ALIGN(n_desc) (((n_desc) >> 8) & 0x0f)
+#define SET_COMM_ALIGN(n_desc,align) \
+    (n_desc) = (((n_desc) & 0xf0ff) | (((align) & 0x0f) << 8))
+
+/*
+ * To support the lazy binding of undefined symbols in the dynamic link-editor,
+ * the undefined symbols in the symbol table (the nlist structures) are marked
+ * with the indication if the undefined reference is a lazy reference or
+ * non-lazy reference.  If both a non-lazy reference and a lazy reference is
+ * made to the same symbol the non-lazy reference takes precedence.  A reference
+ * is lazy only when all references to that symbol are made through a symbol
+ * pointer in a lazy symbol pointer section.
+ *
+ * The implementation of marking nlist structures in the symbol table for
+ * undefined symbols will be to use some of the bits of the n_desc field as a
+ * reference type.  The mask REFERENCE_TYPE will be applied to the n_desc field
+ * of an nlist structure for an undefined symbol to determine the type of
+ * undefined reference (lazy or non-lazy).
+ *
+ * The constants for the REFERENCE FLAGS are propagated to the reference table
+ * in a shared library file.  In that case the constant for a defined symbol,
+ * REFERENCE_FLAG_DEFINED, is also used.
+ */
+/* Reference type bits of the n_desc field of undefined symbols */
+#define REFERENCE_TYPE				0x7
+/* types of references */
+#define REFERENCE_FLAG_UNDEFINED_NON_LAZY		0
+#define REFERENCE_FLAG_UNDEFINED_LAZY			1
+#define REFERENCE_FLAG_DEFINED				2
+#define REFERENCE_FLAG_PRIVATE_DEFINED			3
+#define REFERENCE_FLAG_PRIVATE_UNDEFINED_NON_LAZY	4
+#define REFERENCE_FLAG_PRIVATE_UNDEFINED_LAZY		5
+
+/*
+ * To simplify stripping of objects that use are used with the dynamic link
+ * editor, the static link editor marks the symbols defined an object that are
+ * referenced by a dynamicly bound object (dynamic shared libraries, bundles).
+ * With this marking strip knows not to strip these symbols.
+ */
+#define REFERENCED_DYNAMICALLY	0x0010
+
+/*
+ * For images created by the static link editor with the -twolevel_namespace
+ * option in effect the flags field of the mach header is marked with
+ * MH_TWOLEVEL.  And the binding of the undefined references of the image are
+ * determined by the static link editor.  Which library an undefined symbol is
+ * bound to is recorded by the static linker in the high 8 bits of the n_desc
+ * field using the SET_LIBRARY_ORDINAL macro below.  The ordinal recorded
+ * references the libraries listed in the Mach-O's LC_LOAD_DYLIB,
+ * LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB, LC_LOAD_UPWARD_DYLIB, and
+ * LC_LAZY_LOAD_DYLIB, etc. load commands in the order they appear in the
+ * headers.   The library ordinals start from 1.
+ * For a dynamic library that is built as a two-level namespace image the
+ * undefined references from module defined in another use the same nlist struct
+ * an in that case SELF_LIBRARY_ORDINAL is used as the library ordinal.  For
+ * defined symbols in all images they also must have the library ordinal set to
+ * SELF_LIBRARY_ORDINAL.  The EXECUTABLE_ORDINAL refers to the executable
+ * image for references from plugins that refer to the executable that loads
+ * them.
+ * 
+ * The DYNAMIC_LOOKUP_ORDINAL is for undefined symbols in a two-level namespace
+ * image that are looked up by the dynamic linker with flat namespace semantics.
+ * This ordinal was added as a feature in Mac OS X 10.3 by reducing the
+ * value of MAX_LIBRARY_ORDINAL by one.  So it is legal for existing binaries
+ * or binaries built with older tools to have 0xfe (254) dynamic libraries.  In
+ * this case the ordinal value 0xfe (254) must be treated as a library ordinal
+ * for compatibility. 
+ */
+#define GET_LIBRARY_ORDINAL(n_desc) (((n_desc) >> 8) & 0xff)
+#define SET_LIBRARY_ORDINAL(n_desc,ordinal) \
+	(n_desc) = (((n_desc) & 0x00ff) | (((ordinal) & 0xff) << 8))
+#define SELF_LIBRARY_ORDINAL 0x0
+#define MAX_LIBRARY_ORDINAL 0xfd
+#define DYNAMIC_LOOKUP_ORDINAL 0xfe
+#define EXECUTABLE_ORDINAL 0xff
+
+/*
+ * The bit 0x0020 of the n_desc field is used for two non-overlapping purposes
+ * and has two different symbolic names, N_NO_DEAD_STRIP and N_DESC_DISCARDED.
+ */
+
+/*
+ * The N_NO_DEAD_STRIP bit of the n_desc field only ever appears in a 
+ * relocatable .o file (MH_OBJECT filetype). And is used to indicate to the
+ * static link editor it is never to dead strip the symbol.
+ */
+#define N_NO_DEAD_STRIP 0x0020 /* symbol is not to be dead stripped */
+
+/*
+ * The N_DESC_DISCARDED bit of the n_desc field never appears in linked image.
+ * But is used in very rare cases by the dynamic link editor to mark an in
+ * memory symbol as discared and longer used for linking.
+ */
+#define N_DESC_DISCARDED 0x0020	/* symbol is discarded */
+
+/*
+ * The N_WEAK_REF bit of the n_desc field indicates to the dynamic linker that
+ * the undefined symbol is allowed to be missing and is to have the address of
+ * zero when missing.
+ */
+#define N_WEAK_REF	0x0040 /* symbol is weak referenced */
+
+/*
+ * The N_WEAK_DEF bit of the n_desc field indicates to the static and dynamic
+ * linkers that the symbol definition is weak, allowing a non-weak symbol to
+ * also be used which causes the weak definition to be discared.  Currently this
+ * is only supported for symbols in coalesed sections.
+ */
+#define N_WEAK_DEF	0x0080 /* coalesed symbol is a weak definition */
+
+/*
+ * The N_REF_TO_WEAK bit of the n_desc field indicates to the dynamic linker
+ * that the undefined symbol should be resolved using flat namespace searching.
+ */
+#define	N_REF_TO_WEAK	0x0080 /* reference to a weak symbol */
+
+/*
+ * The N_ARM_THUMB_DEF bit of the n_desc field indicates that the symbol is
+ * a defintion of a Thumb function.
+ */
+#define N_ARM_THUMB_DEF	0x0008 /* symbol is a Thumb function (ARM) */
+
+/*
+ * The N_SYMBOL_RESOLVER bit of the n_desc field indicates that the
+ * that the function is actually a resolver function and should
+ * be called to get the address of the real function to use.
+ * This bit is only available in .o files (MH_OBJECT filetype)
+ */
+#define N_SYMBOL_RESOLVER  0x0100 
+
+/*
+ * The N_ALT_ENTRY bit of the n_desc field indicates that the
+ * symbol is pinned to the previous content.
+ */
+#define N_ALT_ENTRY 0x0200
+
+/*
+ * The N_COLD_FUNC bit of the n_desc field indicates that the symbol is used
+ * infrequently and the linker should order it towards the end of the section.
+ */
+#define N_COLD_FUNC 0x0400
+
+#ifndef __STRICT_BSD__
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+/*
+ * The function nlist(3) from the C library.
+ */
+extern int nlist (const char *filename, struct nlist *list);
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __STRICT_BSD__ */
+
+#endif /* _MACHO_LIST_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/ranlib.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/ranlib.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016 Apple, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*	ranlib.h	4.1	83/05/03	*/
+#ifndef _MACH_O_RANLIB_H_
+#define _MACH_O_RANLIB_H_
+
+#include <stdint.h>
+#include <sys/types.h>		/* off_t */
+
+/*
+ * There are two known orders of table of contents for archives.  The first is
+ * the order ranlib(1) originally produced and still produces without any
+ * options.  This table of contents has the archive member name "__.SYMDEF"
+ * This order has the ranlib structures in the order the objects appear in the
+ * archive and the symbol names of those objects in the order of symbol table.
+ * The second know order is sorted by symbol name and is produced with the -s
+ * option to ranlib(1).  This table of contents has the archive member name
+ * "__.SYMDEF SORTED" and many programs (notably the 1.0 version of ld(1) can't
+ * tell the difference between names because of the imbedded blank in the name
+ * and works with either table of contents).  This second order is used by the
+ * post 1.0 link editor to produce faster linking.  The original 1.0 version of
+ * ranlib(1) gets confused when it is run on a archive with the second type of
+ * table of contents because it and ar(1) which it uses use different ways to
+ * determined the member name (ar(1) treats all blanks in the name as
+ * significant and ranlib(1) only checks for the first one).
+ */
+#define SYMDEF		"__.SYMDEF"
+#define SYMDEF_SORTED	"__.SYMDEF SORTED"
+
+/*
+ * Structure of the __.SYMDEF table of contents for an archive.
+ * __.SYMDEF begins with a uint32_t giving the size in bytes of the ranlib
+ * structures which immediately follow, and then continues with a string
+ * table consisting of a uint32_t giving the number of bytes of strings which
+ * follow and then the strings themselves.  The ran_strx fields index the
+ * string table whose first byte is numbered 0.
+ */
+struct	ranlib {
+    union {
+	uint32_t	ran_strx;	/* string table index of */
+#ifndef __LP64__
+	char		*ran_name;	/* symbol defined by */
+#endif
+    } ran_un;
+    uint32_t		ran_off;	/* library member at this offset */
+};
+
+#define SYMDEF_64		"__.SYMDEF_64"
+#define SYMDEF_64_SORTED	"__.SYMDEF_64 SORTED"
+
+/*
+ * The support for the 64-bit table of contents described here is a work in
+ * progress and not yet fully supported in all the Apple Developer Tools.
+ *
+ * When an archive offset to a library member is more than 32-bits then this is
+ * the structure of the __.SYMDEF_64 table of contents for an archive.
+ * __.SYMDEF_64 begins with a uint64_t giving the size in bytes of the ranlib
+ * structures which immediately follow, and then continues with a string
+ * table consisting of a uint64_t giving the number of bytes of strings which
+ * follow and then the strings themselves.  The ran_strx fields index the
+ * string table whose first byte is numbered 0.
+ */
+
+struct	ranlib_64 {
+    union {
+	uint64_t	ran_strx;	/* string table index of */
+    } ran_un;
+    uint64_t		ran_off;	/* library member at this offset */
+};
+#endif /* _MACH_O_RANLIB_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/reloc.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/reloc.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*	$NetBSD: exec.h,v 1.6 1994/10/27 04:16:05 cgd Exp $	*/
+
+/*
+ * Copyright (c) 1993 Christopher G. Demetriou
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHO_RELOC_H_
+#define _MACHO_RELOC_H_
+#include <stdint.h>
+
+/*
+ * Format of a relocation entry of a Mach-O file.  Modified from the 4.3BSD
+ * format.  The modifications from the original format were changing the value
+ * of the r_symbolnum field for "local" (r_extern == 0) relocation entries.
+ * This modification is required to support symbols in an arbitrary number of
+ * sections not just the three sections (text, data and bss) in a 4.3BSD file.
+ * Also the last 4 bits have had the r_type tag added to them.
+ */
+struct relocation_info {
+   int32_t	r_address;	/* offset in the section to what is being
+				   relocated */
+   uint32_t     r_symbolnum:24,	/* symbol index if r_extern == 1 or section
+				   ordinal if r_extern == 0 */
+		r_pcrel:1, 	/* was relocated pc relative already */
+		r_length:2,	/* 0=byte, 1=word, 2=long, 3=quad */
+		r_extern:1,	/* does not include value of sym referenced */
+		r_type:4;	/* if not 0, machine specific relocation type */
+};
+#define	R_ABS	0		/* absolute relocation type for Mach-O files */
+
+/*
+ * The r_address is not really the address as it's name indicates but an offset.
+ * In 4.3BSD a.out objects this offset is from the start of the "segment" for
+ * which relocation entry is for (text or data).  For Mach-O object files it is
+ * also an offset but from the start of the "section" for which the relocation
+ * entry is for.  See comments in <mach-o/loader.h> about the r_address feild
+ * in images for used with the dynamic linker.
+ * 
+ * In 4.3BSD a.out objects if r_extern is zero then r_symbolnum is an ordinal
+ * for the segment the symbol being relocated is in.  These ordinals are the
+ * symbol types N_TEXT, N_DATA, N_BSS or N_ABS.  In Mach-O object files these
+ * ordinals refer to the sections in the object file in the order their section
+ * structures appear in the headers of the object file they are in.  The first
+ * section has the ordinal 1, the second 2, and so on.  This means that the
+ * same ordinal in two different object files could refer to two different
+ * sections.  And further could have still different ordinals when combined
+ * by the link-editor.  The value R_ABS is used for relocation entries for
+ * absolute symbols which need no further relocation.
+ */
+
+/*
+ * For RISC machines some of the references are split across two instructions
+ * and the instruction does not contain the complete value of the reference.
+ * In these cases a second, or paired relocation entry, follows each of these
+ * relocation entries, using a PAIR r_type, which contains the other part of the
+ * reference not contained in the instruction.  This other part is stored in the
+ * pair's r_address field.  The exact number of bits of the other part of the
+ * reference store in the r_address field is dependent on the particular
+ * relocation type for the particular architecture.
+ */
+
+/*
+ * To make scattered loading by the link editor work correctly "local"
+ * relocation entries can't be used when the item to be relocated is the value
+ * of a symbol plus an offset (where the resulting expresion is outside the
+ * block the link editor is moving, a blocks are divided at symbol addresses).
+ * In this case. where the item is a symbol value plus offset, the link editor
+ * needs to know more than just the section the symbol was defined.  What is
+ * needed is the actual value of the symbol without the offset so it can do the
+ * relocation correctly based on where the value of the symbol got relocated to
+ * not the value of the expression (with the offset added to the symbol value).
+ * So for the NeXT 2.0 release no "local" relocation entries are ever used when
+ * there is a non-zero offset added to a symbol.  The "external" and "local"
+ * relocation entries remain unchanged.
+ *
+ * The implemention is quite messy given the compatibility with the existing
+ * relocation entry format.  The ASSUMPTION is that a section will never be
+ * bigger than 2**24 - 1 (0x00ffffff or 16,777,215) bytes.  This assumption
+ * allows the r_address (which is really an offset) to fit in 24 bits and high
+ * bit of the r_address field in the relocation_info structure to indicate
+ * it is really a scattered_relocation_info structure.  Since these are only
+ * used in places where "local" relocation entries are used and not where
+ * "external" relocation entries are used the r_extern field has been removed.
+ *
+ * For scattered loading to work on a RISC machine where some of the references
+ * are split across two instructions the link editor needs to be assured that
+ * each reference has a unique 32 bit reference (that more than one reference is
+ * NOT sharing the same high 16 bits for example) so it move each referenced
+ * item independent of each other.  Some compilers guarantees this but the
+ * compilers don't so scattered loading can be done on those that do guarantee
+ * this.
+ */
+#if defined(__BIG_ENDIAN__) || defined(__LITTLE_ENDIAN__)
+/*
+ * The reason for the ifdef's of __BIG_ENDIAN__ and __LITTLE_ENDIAN__ are that
+ * when stattered relocation entries were added the mistake of using a mask
+ * against a structure that is made up of bit fields was used.  To make this
+ * design work this structure must be laid out in memory the same way so the
+ * mask can be applied can check the same bit each time (r_scattered).
+ */
+#endif /* defined(__BIG_ENDIAN__) || defined(__LITTLE_ENDIAN__) */
+#define R_SCATTERED 0x80000000	/* mask to be applied to the r_address field 
+				   of a relocation_info structure to tell that
+				   is is really a scattered_relocation_info
+				   stucture */
+struct scattered_relocation_info {
+#ifdef __BIG_ENDIAN__
+   uint32_t	r_scattered:1,	/* 1=scattered, 0=non-scattered (see above) */
+		r_pcrel:1, 	/* was relocated pc relative already */
+		r_length:2,	/* 0=byte, 1=word, 2=long, 3=quad */
+		r_type:4,	/* if not 0, machine specific relocation type */
+   		r_address:24;	/* offset in the section to what is being
+				   relocated */
+   int32_t	r_value;	/* the value the item to be relocated is
+				   refering to (without any offset added) */
+#endif /* __BIG_ENDIAN__ */
+#ifdef __LITTLE_ENDIAN__
+   uint32_t
+   		r_address:24,	/* offset in the section to what is being
+				   relocated */
+		r_type:4,	/* if not 0, machine specific relocation type */
+		r_length:2,	/* 0=byte, 1=word, 2=long, 3=quad */
+		r_pcrel:1, 	/* was relocated pc relative already */
+		r_scattered:1;	/* 1=scattered, 0=non-scattered (see above) */
+   int32_t	r_value;	/* the value the item to be relocated is
+				   refering to (without any offset added) */
+#endif /* __LITTLE_ENDIAN__ */
+};
+
+/*
+ * Relocation types used in a generic implementation.  Relocation entries for
+ * normal things use the generic relocation as discribed above and their r_type
+ * is GENERIC_RELOC_VANILLA (a value of zero).
+ *
+ * Another type of generic relocation, GENERIC_RELOC_SECTDIFF, is to support
+ * the difference of two symbols defined in different sections.  That is the
+ * expression "symbol1 - symbol2 + constant" is a relocatable expression when
+ * both symbols are defined in some section.  For this type of relocation the
+ * both relocations entries are scattered relocation entries.  The value of
+ * symbol1 is stored in the first relocation entry's r_value field and the
+ * value of symbol2 is stored in the pair's r_value field.
+ *
+ * A special case for a prebound lazy pointer is needed to beable to set the
+ * value of the lazy pointer back to its non-prebound state.  This is done
+ * using the GENERIC_RELOC_PB_LA_PTR r_type.  This is a scattered relocation
+ * entry where the r_value feild is the value of the lazy pointer not prebound.
+ */
+enum reloc_type_generic
+{
+    GENERIC_RELOC_VANILLA,	/* generic relocation as discribed above */
+    GENERIC_RELOC_PAIR,		/* Only follows a GENERIC_RELOC_SECTDIFF */
+    GENERIC_RELOC_SECTDIFF,
+    GENERIC_RELOC_PB_LA_PTR,	/* prebound lazy pointer */
+    GENERIC_RELOC_LOCAL_SECTDIFF,
+    GENERIC_RELOC_TLV		/* thread local variables */
+};
+
+#endif /* _MACHO_RELOC_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/stab.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/stab.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#ifndef _MACHO_STAB_H_
+#define _MACHO_STAB_H_
+/*	$NetBSD: stab.h,v 1.4 1994/10/26 00:56:25 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1991 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)stab.h	5.2 (Berkeley) 4/4/91
+ */
+
+/*
+ * This file gives definitions supplementing <nlist.h> for permanent symbol
+ * table entries of Mach-O files.  Modified from the BSD definitions.  The
+ * modifications from the original definitions were changing what the values of
+ * what was the n_other field (an unused field) which is now the n_sect field.
+ * These modifications are required to support symbols in an arbitrary number of
+ * sections not just the three sections (text, data and bss) in a BSD file.
+ * The values of the defined constants have NOT been changed.
+ *
+ * These must have one of the N_STAB bits on.  The n_value fields are subject
+ * to relocation according to the value of their n_sect field.  So for types
+ * that refer to things in sections the n_sect field must be filled in with the
+ * proper section ordinal.  For types that are not to have their n_value field 
+ * relocatated the n_sect field must be NO_SECT.
+ */
+
+/*
+ * Symbolic debugger symbols.  The comments give the conventional use for
+ * 
+ * 	.stabs "n_name", n_type, n_sect, n_desc, n_value
+ *
+ * where n_type is the defined constant and not listed in the comment.  Other
+ * fields not listed are zero. n_sect is the section ordinal the entry is
+ * refering to.
+ */
+#define	N_GSYM	0x20	/* global symbol: name,,NO_SECT,type,0 */
+#define	N_FNAME	0x22	/* procedure name (f77 kludge): name,,NO_SECT,0,0 */
+#define	N_FUN	0x24	/* procedure: name,,n_sect,linenumber,address */
+#define	N_STSYM	0x26	/* static symbol: name,,n_sect,type,address */
+#define	N_LCSYM	0x28	/* .lcomm symbol: name,,n_sect,type,address */
+#define N_BNSYM 0x2e	/* begin nsect sym: 0,,n_sect,0,address */
+#define N_AST	0x32	/* AST file path: name,,NO_SECT,0,0 */
+#define N_OPT	0x3c	/* emitted with gcc2_compiled and in gcc source */
+#define	N_RSYM	0x40	/* register sym: name,,NO_SECT,type,register */
+#define	N_SLINE	0x44	/* src line: 0,,n_sect,linenumber,address */
+#define N_ENSYM 0x4e	/* end nsect sym: 0,,n_sect,0,address */
+#define	N_SSYM	0x60	/* structure elt: name,,NO_SECT,type,struct_offset */
+#define	N_SO	0x64	/* source file name: name,,n_sect,0,address */
+#define	N_OSO	0x66	/* object file name: name,,(see below),0,st_mtime */
+			/*   historically N_OSO set n_sect to 0. The N_OSO
+			 *   n_sect may instead hold the low byte of the
+			 *   cpusubtype value from the Mach-O header. */
+#define	N_LSYM	0x80	/* local sym: name,,NO_SECT,type,offset */
+#define N_BINCL	0x82	/* include file beginning: name,,NO_SECT,0,sum */
+#define	N_SOL	0x84	/* #included file name: name,,n_sect,0,address */
+#define	N_PARAMS  0x86	/* compiler parameters: name,,NO_SECT,0,0 */
+#define	N_VERSION 0x88	/* compiler version: name,,NO_SECT,0,0 */
+#define	N_OLEVEL  0x8A	/* compiler -O level: name,,NO_SECT,0,0 */
+#define	N_PSYM	0xa0	/* parameter: name,,NO_SECT,type,offset */
+#define N_EINCL	0xa2	/* include file end: name,,NO_SECT,0,0 */
+#define	N_ENTRY	0xa4	/* alternate entry: name,,n_sect,linenumber,address */
+#define	N_LBRAC	0xc0	/* left bracket: 0,,NO_SECT,nesting level,address */
+#define N_EXCL	0xc2	/* deleted include file: name,,NO_SECT,0,sum */
+#define	N_RBRAC	0xe0	/* right bracket: 0,,NO_SECT,nesting level,address */
+#define	N_BCOMM	0xe2	/* begin common: name,,NO_SECT,0,0 */
+#define	N_ECOMM	0xe4	/* end common: name,,n_sect,0,0 */
+#define	N_ECOML	0xe8	/* end common (local name): 0,,n_sect,0,address */
+#define	N_LENG	0xfe	/* second stab entry with length information */
+
+/*
+ * for the berkeley pascal compiler, pc(1):
+ */
+#define	N_PC	0x30	/* global pascal symbol: name,,NO_SECT,subtype,line */
+
+#endif /* _MACHO_STAB_H_ */

--- a/libc/include/aarch64-macos-gnu/mach-o/x86_64/reloc.h
+++ b/libc/include/aarch64-macos-gnu/mach-o/x86_64/reloc.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2006 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*
+ * Relocations for x86_64 are a bit different than for other architectures in
+ * Mach-O: Scattered relocations are not used.  Almost all relocations produced
+ * by the compiler are external relocations.  An external relocation has the
+ * r_extern bit set to 1 and the r_symbolnum field contains the symbol table
+ * index of the target label.
+ * 
+ * When the assembler is generating relocations, if the target label is a local
+ * label (begins with 'L'), then the previous non-local label in the same
+ * section is used as the target of the external relocation.  An addend is used
+ * with the distance from that non-local label to the target label.  Only when
+ * there is no previous non-local label in the section is an internal
+ * relocation used.
+ * 
+ * The addend (i.e. the 4 in _foo+4) is encoded in the instruction (Mach-O does
+ * not have RELA relocations).  For PC-relative relocations, the addend is
+ * stored directly in the instruction.  This is different from other Mach-O
+ * architectures, which encode the addend minus the current section offset.
+ * 
+ * The relocation types are:
+ * 
+ * 	X86_64_RELOC_UNSIGNED	// for absolute addresses
+ * 	X86_64_RELOC_SIGNED		// for signed 32-bit displacement
+ * 	X86_64_RELOC_BRANCH		// a CALL/JMP instruction with 32-bit displacement
+ * 	X86_64_RELOC_GOT_LOAD	// a MOVQ load of a GOT entry
+ * 	X86_64_RELOC_GOT		// other GOT references
+ * 	X86_64_RELOC_SUBTRACTOR	// must be followed by a X86_64_RELOC_UNSIGNED
+ * 
+ * The following are sample assembly instructions, followed by the relocation
+ * and section content they generate in an object file:
+ * 
+ * 	call _foo
+ * 		r_type=X86_64_RELOC_BRANCH, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		E8 00 00 00 00
+ * 
+ * 	call _foo+4
+ * 		r_type=X86_64_RELOC_BRANCH, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		E8 04 00 00 00 
+ * 
+ * 	movq _foo@GOTPCREL(%rip), %rax
+ * 		r_type=X86_64_RELOC_GOT_LOAD, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		48 8B 05 00 00 00 00
+ * 	
+ * 	pushq _foo@GOTPCREL(%rip)
+ * 		r_type=X86_64_RELOC_GOT, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		FF 35 00 00 00 00
+ * 	
+ * 	movl _foo(%rip), %eax
+ * 		r_type=X86_64_RELOC_SIGNED, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		8B 05 00 00 00 00
+ * 
+ * 	movl _foo+4(%rip), %eax
+ * 		r_type=X86_64_RELOC_SIGNED, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		8B 05 04 00 00 00
+ * 
+ * 	movb  $0x12, _foo(%rip)
+ * 		r_type=X86_64_RELOC_SIGNED, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		C6 05 FF FF FF FF 12
+ * 
+ * 	movl  $0x12345678, _foo(%rip)
+ * 		r_type=X86_64_RELOC_SIGNED, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
+ * 		C7 05 FC FF FF FF 78 56 34 12
+ * 
+ * 	.quad _foo
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		00 00 00 00 00 00 00 00
+ * 
+ * 	.quad _foo+4
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		04 00 00 00 00 00 00 00
+ * 
+ * 	.quad _foo - _bar
+ * 		r_type=X86_64_RELOC_SUBTRACTOR, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_bar
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		00 00 00 00 00 00 00 00
+ * 
+ * 	.quad _foo - _bar + 4
+ * 		r_type=X86_64_RELOC_SUBTRACTOR, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_bar
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		04 00 00 00 00 00 00 00
+ * 	
+ * 	.long _foo - _bar
+ * 		r_type=X86_64_RELOC_SUBTRACTOR, r_length=2, r_extern=1, r_pcrel=0, r_symbolnum=_bar
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=2, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		00 00 00 00
+ * 
+ * 	lea L1(%rip), %rax
+ * 		r_type=X86_64_RELOC_SIGNED, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_prev
+ * 		48 8d 05 12 00 00 00
+ * 		// assumes _prev is the first non-local label 0x12 bytes before L1
+ * 
+ * 	lea L0(%rip), %rax
+ * 		r_type=X86_64_RELOC_SIGNED, r_length=2, r_extern=0, r_pcrel=1, r_symbolnum=3
+ * 		48 8d 05 56 00 00 00
+ *		// assumes L0 is in third section and there is no previous non-local label.
+ *		// The rip-relative-offset of 0x00000056 is L0-address_of_next_instruction.
+ *		// address_of_next_instruction is the address of the relocation + 4.
+ *
+ *     add     $6,L0(%rip)
+ *             r_type=X86_64_RELOC_SIGNED_1, r_length=2, r_extern=0, r_pcrel=1, r_symbolnum=3
+ *		83 05 18 00 00 00 06
+ *		// assumes L0 is in third section and there is no previous non-local label.
+ *		// The rip-relative-offset of 0x00000018 is L0-address_of_next_instruction.
+ *		// address_of_next_instruction is the address of the relocation + 4 + 1.
+ *		// The +1 comes from SIGNED_1.  This is used because the relocation is not
+ *		// at the end of the instruction.
+ *
+ * 	.quad L1
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_prev
+ * 		12 00 00 00 00 00 00 00
+ * 		// assumes _prev is the first non-local label 0x12 bytes before L1
+ * 
+ * 	.quad L0
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=0, r_pcrel=0, r_symbolnum=3
+ * 		56 00 00 00 00 00 00 00
+ * 		// assumes L0 is in third section, has an address of 0x00000056 in .o
+ * 		// file, and there is no previous non-local label
+ * 
+ * 	.quad _foo - .
+ * 		r_type=X86_64_RELOC_SUBTRACTOR, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_prev
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		EE FF FF FF FF FF FF FF
+ * 		// assumes _prev is the first non-local label 0x12 bytes before this
+ * 		// .quad
+ * 
+ * 	.quad _foo - L1
+ * 		r_type=X86_64_RELOC_SUBTRACTOR, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_prev
+ * 		r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_extern=1, r_pcrel=0, r_symbolnum=_foo
+ * 		EE FF FF FF FF FF FF FF
+ * 		// assumes _prev is the first non-local label 0x12 bytes before L1
+ * 
+ * 	.quad L1 - _prev
+ * 		// No relocations.  This is an assembly time constant.
+ * 		12 00 00 00 00 00 00 00
+ * 		// assumes _prev is the first non-local label 0x12 bytes before L1
+ *
+ *
+ *
+ * In final linked images, there are only two valid relocation kinds:
+ *
+ *     r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_pcrel=0, r_extern=1, r_symbolnum=sym_index
+ *	This tells dyld to add the address of a symbol to a pointer sized (8-byte)
+ *  piece of data (i.e on disk the 8-byte piece of data contains the addend). The 
+ *  r_symbolnum contains the index into the symbol table of the target symbol.
+ *
+ *     r_type=X86_64_RELOC_UNSIGNED, r_length=3, r_pcrel=0, r_extern=0, r_symbolnum=0
+ * This tells dyld to adjust the pointer sized (8-byte) piece of data by the amount
+ * the containing image was loaded from its base address (e.g. slide).
+ *
+ */ 
+enum reloc_type_x86_64
+{
+	X86_64_RELOC_UNSIGNED,		// for absolute addresses
+	X86_64_RELOC_SIGNED,		// for signed 32-bit displacement
+	X86_64_RELOC_BRANCH,		// a CALL/JMP instruction with 32-bit displacement
+	X86_64_RELOC_GOT_LOAD,		// a MOVQ load of a GOT entry
+	X86_64_RELOC_GOT,			// other GOT references
+	X86_64_RELOC_SUBTRACTOR,	// must be followed by a X86_64_RELOC_UNSIGNED
+	X86_64_RELOC_SIGNED_1,		// for signed 32-bit displacement with a -1 addend
+	X86_64_RELOC_SIGNED_2,		// for signed 32-bit displacement with a -2 addend
+	X86_64_RELOC_SIGNED_4,		// for signed 32-bit displacement with a -4 addend
+	X86_64_RELOC_TLV,		// for thread local variables
+};

--- a/src/headers.c
+++ b/src/headers.c
@@ -128,6 +128,16 @@
 #include <xlocale.h>
 #include <copyfile.h>
 #include <mach-o/dyld.h>
+#include <mach-o/fat.h>
+#include <mach-o/nlist.h>
+#include <mach-o/reloc.h>
+#include <mach-o/arch.h>
+#include <mach-o/stab.h>
+#include <mach-o/ranlib.h>
+#include <mach-o/compact_unwind_encoding.h>
+#include <mach-o/arm64/reloc.h>
+#include <mach-o/x86_64/reloc.h>
+#include <ar.h>
 
 // Depended on by LLVM
 #include <sysexits.h>
@@ -150,6 +160,7 @@
 #include <os/lock.h>
 #include <simd/simd.h>
 #include <xpc/xpc.h>
+#include <CommonCrypto/CommonDigest.h>
 
 // Depended on by libuv
 #include <ifaddrs.h>

--- a/src/main.zig
+++ b/src/main.zig
@@ -230,7 +230,9 @@ fn installHeaders(allocator: *Allocator, args: []const []const u8) !void {
         std.fmt.fmtIntSizeBin(savings.total_bytes - savings.max_bytes_saved),
     });
 
-    var tmp = tmpDir(.{ .iterate=true, });
+    var tmp = tmpDir(.{
+        .iterate = true,
+    });
     defer tmp.cleanup();
 
     var missed_opportunity_bytes: usize = 0;
@@ -286,7 +288,9 @@ fn installHeaders(allocator: *Allocator, args: []const []const u8) !void {
     while (try tmp_it.next()) |entry| {
         switch (entry.kind) {
             .Directory => {
-                const sub_dir = try tmp.dir.openDir(entry.name, .{ .iterate=true, });
+                const sub_dir = try tmp.dir.openDir(entry.name, .{
+                    .iterate = true,
+                });
                 const install_sub_dir = try install_dir.makeOpenPath(entry.name, .{});
                 try copyDirAll(sub_dir, install_sub_dir);
             },
@@ -317,7 +321,9 @@ fn findDuplicates(
     try dir_stack.append(target_include_dir);
 
     while (dir_stack.popOrNull()) |full_dir_name| {
-        var dir = fs.cwd().openDir(full_dir_name, .{ .iterate=true, }) catch |err| switch (err) {
+        var dir = fs.cwd().openDir(full_dir_name, .{
+            .iterate = true,
+        }) catch |err| switch (err) {
             error.FileNotFound => break,
             error.AccessDenied => break,
             else => return err,
@@ -381,7 +387,9 @@ fn copyDirAll(source: fs.Dir, dest: fs.Dir) anyerror!void {
         switch (next.kind) {
             .Directory => {
                 var sub_dir = try dest.makeOpenPath(next.name, .{});
-                var sub_source = try source.openDir(next.name, .{ .iterate=true, });
+                var sub_source = try source.openDir(next.name, .{
+                    .iterate = true,
+                });
                 defer {
                     sub_dir.close();
                     sub_source.close();


### PR DESCRIPTION
In particular:

* redo README with clear step-by-step instructions
* add hint with tl;dr instruction to the binary itself
* improve CLI by making both commands explicit
* improve error messages for basic error conditions such as missing dirs
