### PR TITLE
correct unused function parameters

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -80,15 +80,18 @@ const Contents = struct {
     is_generic: bool,
 
     fn hitCountLessThan(context: void, lhs: *const Contents, rhs: *const Contents) bool {
+        _ = context;
         return lhs.hit_count < rhs.hit_count;
     }
 };
 
 const TargetToHashContext = struct {
     pub fn hash(self: @This(), target: Target) u32 {
+        _ = self;
         return target.hash();
     }
     pub fn eql(self: @This(), a: Target, b: Target) bool {
+        _ = self;
         return a.eql(b);
     }
 };


### PR DESCRIPTION
Fixes issues which prevent building with latest nightly Zig:

```
% zig build
/Users/slimsag/Desktop/fetch-them-macos-headers/src/main.zig:82:25: error: unused function parameter
    fn hitCountLessThan(context: void, lhs: *const Contents, rhs: *const Contents) bool {
                        ^
/Users/slimsag/Desktop/fetch-them-macos-headers/src/main.zig:88:17: error: unused function parameter
    pub fn hash(self: @This(), target: Target) u32 {
                ^
/Users/slimsag/Desktop/fetch-them-macos-headers/src/main.zig:91:16: error: unused function parameter
    pub fn eql(self: @This(), a: Target, b: Target) bool {
               ^
```

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>