### PR TITLE
add .gitignore and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
-zig-cache
+# This file is for zig-specific build artifacts.
+# If you have OS-specific or editor-specific files to ignore,
+# such as *.swp or .DS_Store, put those in your global
+# ~/.gitignore and put this in your ~/.gitconfig:
+#
+# [core]
+#     excludesfile = ~/.gitignore
+#
+# Cheers!
+# -andrewrk
+
+zig-cache/
+zig-out/
+/release/
+/debug/
+/build/
+/build-*/
+/docgen_tmp/


### PR DESCRIPTION
* Adds `.gitignore` (from the ziglang/zig repository, I noticed `zig-out` wasn't excluded.
* Adds a `.gitattributes` which ensures your `.zig` and `.c` files don't end up with CRLF.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>