### PR TITLE
Add missing BSD libc headers

### DIFF
--- a/src/headers.c
+++ b/src/headers.c
@@ -27,6 +27,12 @@
 #include <wchar.h>
 #include <wctype.h>
 
+// Source: https://en.wikipedia.org/wiki/C_standard_library#BSD_libc
+#include <fts.h>
+#include <db.h>
+#include <err.h>
+#include <vis.h>
+
 // Source: https://en.wikipedia.org/wiki/C_POSIX_library
 #include <aio.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Adds some headers from https://en.wikipedia.org/wiki/C_standard_library#BSD_libc.

For https://github.com/ziglang/zig/issues/14184