### PR TITLE
Update to latest zig and include paths.h

### DIFF
--- a/headers/aarch64-macos.13-none/paths.h
+++ b/headers/aarch64-macos.13-none/paths.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*	$OpenBSD: paths.h,v 1.10 1997/11/09 00:29:02 bri Exp $	*/
+/*	$NetBSD: paths.h,v 1.10 1997/04/23 09:41:38 lukem Exp $	*/
+
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)paths.h	8.1 (Berkeley) 6/2/93
+ */
+
+#ifndef _PATHS_H_
+#define	_PATHS_H_
+
+/* Default search path. */
+#define	_PATH_DEFPATH	"/usr/bin:/bin"
+/* All standard utilities path. */
+#define	_PATH_STDPATH	"/usr/bin:/bin:/usr/sbin:/sbin"
+
+#define	_PATH_BSHELL	"/bin/sh"
+#define	_PATH_CONSOLE	"/dev/console"
+#define	_PATH_CSHELL	"/bin/csh"
+#define _PATH_DEFTAPE	"/dev/nrst0"
+#define	_PATH_DEVDB	"/var/run/dev.db"
+#define	_PATH_DEVNULL	"/dev/null"
+#define	_PATH_DRUM	"/dev/drum"
+#define	_PATH_FSIRAND	"/sbin/fsirand"
+#define	_PATH_KMEM	"/dev/kmem"
+#define	_PATH_KVMDB	"/var/db/kvm.db"
+#define	_PATH_LOCALE	"/usr/share/locale"
+#define	_PATH_MAILDIR	"/var/mail"
+#define	_PATH_MAN	"/usr/share/man"
+#define	_PATH_MEM	"/dev/mem"
+#define	_PATH_NOLOGIN	"/etc/nologin"
+#define	_PATH_RSH	"/usr/bin/rsh"
+#define	_PATH_SENDMAIL	"/usr/sbin/sendmail"
+#define	_PATH_SHELLS	"/etc/shells"
+#define	_PATH_TTY	"/dev/tty"
+#define	_PATH_UNIX	"/mach"
+#define	_PATH_VI	"/usr/bin/vi"
+
+/* Provide trailing slash, since mostly used for building pathnames. */
+#define	_PATH_DEV	"/dev/"
+#define	_PATH_TMP	"/tmp/"
+#define	_PATH_UUCPLOCK	"/var/spool/lock/"
+#define	_PATH_VARDB	"/var/db/"
+#define	_PATH_VARRUN	"/var/run/"
+#define	_PATH_VARTMP	"/var/tmp/"
+
+#include <sys/paths.h>
+
+#endif /* !_PATHS_H_ */

--- a/headers/x86_64-macos.13-none/paths.h
+++ b/headers/x86_64-macos.13-none/paths.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*	$OpenBSD: paths.h,v 1.10 1997/11/09 00:29:02 bri Exp $	*/
+/*	$NetBSD: paths.h,v 1.10 1997/04/23 09:41:38 lukem Exp $	*/
+
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)paths.h	8.1 (Berkeley) 6/2/93
+ */
+
+#ifndef _PATHS_H_
+#define	_PATHS_H_
+
+/* Default search path. */
+#define	_PATH_DEFPATH	"/usr/bin:/bin"
+/* All standard utilities path. */
+#define	_PATH_STDPATH	"/usr/bin:/bin:/usr/sbin:/sbin"
+
+#define	_PATH_BSHELL	"/bin/sh"
+#define	_PATH_CONSOLE	"/dev/console"
+#define	_PATH_CSHELL	"/bin/csh"
+#define _PATH_DEFTAPE	"/dev/nrst0"
+#define	_PATH_DEVDB	"/var/run/dev.db"
+#define	_PATH_DEVNULL	"/dev/null"
+#define	_PATH_DRUM	"/dev/drum"
+#define	_PATH_FSIRAND	"/sbin/fsirand"
+#define	_PATH_KMEM	"/dev/kmem"
+#define	_PATH_KVMDB	"/var/db/kvm.db"
+#define	_PATH_LOCALE	"/usr/share/locale"
+#define	_PATH_MAILDIR	"/var/mail"
+#define	_PATH_MAN	"/usr/share/man"
+#define	_PATH_MEM	"/dev/mem"
+#define	_PATH_NOLOGIN	"/etc/nologin"
+#define	_PATH_RSH	"/usr/bin/rsh"
+#define	_PATH_SENDMAIL	"/usr/sbin/sendmail"
+#define	_PATH_SHELLS	"/etc/shells"
+#define	_PATH_TTY	"/dev/tty"
+#define	_PATH_UNIX	"/mach"
+#define	_PATH_VI	"/usr/bin/vi"
+
+/* Provide trailing slash, since mostly used for building pathnames. */
+#define	_PATH_DEV	"/dev/"
+#define	_PATH_TMP	"/tmp/"
+#define	_PATH_UUCPLOCK	"/var/spool/lock/"
+#define	_PATH_VARDB	"/var/db/"
+#define	_PATH_VARRUN	"/var/run/"
+#define	_PATH_VARTMP	"/var/tmp/"
+
+#include <sys/paths.h>
+
+#endif /* !_PATHS_H_ */

--- a/src/headers.c
+++ b/src/headers.c
@@ -186,6 +186,7 @@
 #include <objc/objc-runtime.h>
 
 // Depended on by libuv
+#include <paths.h>
 #include <ifaddrs.h>
 #include <net/if_dl.h>
 #include <sys/paths.h>


### PR DESCRIPTION
The latest version of libuv requires the paths.h header from libc. Updated the tool to work with the latest development version of zig, and included paths.h into headers.c.

I unfortunately only have the sysroot available for MacOS 13 and seem to have issues downloading/mounting the other sysroot versions.

cc @kubkon if you could also run and push paths.h for the older sysroot versions via. `fetch-them-macos-headers fetch`.

Resolves #24.